### PR TITLE
Add error handling for google sign in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3927,6 +3927,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -10104,6 +10109,14 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      }
+    },
+    "react-toastify": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-8.2.0.tgz",
+      "integrity": "sha512-Pg2Ju7NngAamarFvLwqrFomJ57u/Ay6i6zfLurt/qPynWkAkOthu6vxfqYpJCyNhHRhR4hu7+bySSeWWJu6PAg==",
+      "requires": {
+        "clsx": "^1.1.1"
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-router": "^6.3.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.0",
+    "react-toastify": "^8.2.0",
     "styled-components": "^5.3.5",
     "web-vitals": "^2.1.4"
   },

--- a/src/components/auth/GoogleContinueButton.jsx
+++ b/src/components/auth/GoogleContinueButton.jsx
@@ -3,9 +3,11 @@ import log from 'loglevel';
 import React from 'react';
 import { useGoogleLogin } from 'react-google-login';
 import { useNavigate } from 'react-router-dom';
+import { ToastContainer, toast } from 'react-toastify';
 import logo from '../../assets/google.svg';
 import refreshTokenSetup from '../../utils/refreshToken';
 import RouteConstants from '../../constants/RouteConstants';
+import 'react-toastify/dist/ReactToastify.css';
 
 const clientId = process.env.REACT_APP_CLIENT_ID;
 
@@ -20,7 +22,15 @@ function GoogleContinueButton() {
 
   const onFailure = (res) => {
     log.error('Login failed: res:', res);
-    navigate('/home');
+    toast.error('Whoops.. There was a problem signing in', {
+      position: 'bottom-center',
+      autoClose: 5000,
+      hideProgressBar: false,
+      closeOnClick: true,
+      pauseOnHover: true,
+      draggable: true,
+      progress: undefined,
+    });
   };
 
   const { signIn } = useGoogleLogin({
@@ -33,10 +43,13 @@ function GoogleContinueButton() {
   });
 
   return (
-    <button type="submit" onClick={signIn} className="button">
-      <img src={logo} alt="google login" className="icon" />
-      <span className="buttonText">Continue with Google</span>
-    </button>
+    <>
+      <button type="submit" onClick={signIn} className="button">
+        <img src={logo} alt="google login" className="icon" />
+        <span className="buttonText">Continue with Google</span>
+      </button>
+      <ToastContainer />
+    </>
   );
 }
 


### PR DESCRIPTION
**Notes**
- Add error handling to google sign in
  - Show error toast when sign in fails
  - Used `react-toastify` library

**Testing**
- `npm ci && npm run watch`
- `python3 app.py`